### PR TITLE
mmc: add 5.0 emmc support

### DIFF
--- a/drivers/mmc/core/mmc.c
+++ b/drivers/mmc/core/mmc.c
@@ -293,7 +293,7 @@ static int mmc_read_ext_csd(struct mmc_card *card, u8 *ext_csd)
 	}
 
 	card->ext_csd.rev = ext_csd[EXT_CSD_REV];
-	if (card->ext_csd.rev > 6) {
+	if (card->ext_csd.rev > 7) {
 		pr_err("%s: unrecognised EXT_CSD revision %d\n",
 			mmc_hostname(card->host), card->ext_csd.rev);
 		err = -EINVAL;


### PR DESCRIPTION
bug: 17968808 Kernel change for new eMMC v5.0 parts for FLO/DEB

Change-Id: Ia18152457fe3ff70401b199c267fa37374b9d544
Signed-off-by: hsuan-chih_chen hsuan-chih_chen@asus.com

Recently manufactured Nexus7 2013 's eMMC revision is changed.
If we do not apply this patch, Nexus can not find any internal storage.
This happens Android version 5.0 is pre-installed Nexus7 2013 devices.
